### PR TITLE
Parse zuliprc file directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ htmlcov
 # Zulip RC
 zuliprc
 .zuliprc
-zuliprc.py
 
 # Personal backup we suggest creating
 *-backup.json

--- a/README.md
+++ b/README.md
@@ -1,33 +1,31 @@
 ## Get an API key
 
-[Follow these instructions](https://zulip.com/api/api-keys) to get a `zuliprc` file in this directory.
-
-Copy `zuliprc.py.template` into a new file called `zuliprc.py`. Then fill out the values from your zuliprc file in the `zuliprc.py`
+[Follow these instructions](https://zulip.com/api/api-keys) to get a `zuliprc` file. Place it in the root of this directory.
 
 ## Make a backup of ALL streams in the zulip instance
 
-The stream subscription API endpoint has the caveat that if we attempt to subscribe to a stream which does not exist, it creates it. This scares the shit out of us, because we're doing a bulk operation. So we are going to be extra safe and do some sort of verification that each stream we attempt to subscribe to actually exists first. 
+The stream subscription API endpoint has the caveat that if we attempt to subscribe to a stream which does not exist, it creates it. This scares the shit out of us, because we're doing a bulk operation. So we are going to be extra safe and do some sort of verification that each stream we attempt to subscribe to actually exists first.
 
 On second thought, we're just goin for it. You only live once. But we'll make a backup just in case we screw something up.
 
 ``` sh
-$ python3 get-all-streams.py > all-streams-backup.json
+python3 get-all-streams.py > all-streams-backup.json
 ```
 
-Note: Reverting based on this backup is left as an exercise to the reader. 
+Note: Reverting based on this backup is left as an exercise to the reader.
 
 ## Make a backup of your current subscriptions
 
 ``` sh
-$ python3 get-all-my-subscriptions.py > my-subscriptions-backup.json
+python3 get-all-my-subscriptions.py > my-subscriptions-backup.json
 ```
 
-Note: Reverting based on this backup is left as an exercise to the reader. 
+Note: Reverting based on this backup is left as an exercise to the reader.
 
 ## Subscribe to all streams
 
 NOTE: Do the backup above before you do this, if you want to go back to your current life easily.
 
 ``` sh
-$ python3 subscribe-to-all-streams.py
+python3 subscribe-to-all-streams.py
 ```

--- a/zuliprc.py
+++ b/zuliprc.py
@@ -1,0 +1,23 @@
+import sys
+
+try:
+    file = open('zuliprc', 'r', encoding='utf-8')
+except FileNotFoundError:
+    print("Could not find zuliprc file. Did you put it in the source root?", file=sys.stderr)
+    sys.exit(1)
+
+for line in file:
+    # skip the lines that don't have key value pairs
+    if (line.find('=') < 0):
+        continue
+
+    key, value = line.split('=')
+    value = value[:-1] # drop the trailing newline
+    if (key == 'email'):
+        email = value
+    if (key == 'key'):
+        api_key = value
+    if (key == 'site'):
+        baseurl = value
+
+auth = (email, api_key)

--- a/zuliprc.py.template
+++ b/zuliprc.py.template
@@ -1,2 +1,0 @@
-auth = ('<your zulip email here>', '<your zulip api key here>')
-baseurl = 'https://yourZulipDomain.zulipchat.com'


### PR DESCRIPTION
Quick and dirty parsing of the zuliprc file. This would break if the file format changes, so hopefully it doesn't do that. The parser should be very simple to update if that happens.

I also removed the leading `$` from the example commands, because it made them hard to copy with the "copy" button.